### PR TITLE
043: edited landing page title, help text not appear when not filled

### DIFF
--- a/task-management-system/imports/ui/components/general/whiteBackground/WhiteBackground.jsx
+++ b/task-management-system/imports/ui/components/general/whiteBackground/WhiteBackground.jsx
@@ -75,12 +75,15 @@ export const WhiteBackground = ({children, className, pageLayout, pageHelpText, 
         <div style={outerDivStyle}>
             <div {...divProps} className={pageMainDivClasses}>
                 {/*todo: make only appear when there is text*/}
-                <HoverTip icon={questionIcon}
-                          outerText={"Help"}
-                          toolTipText={pageHelpText}
-                          divClassName={"page-help-tip"}
-                          textClassname
-                />
+                {
+                    pageHelpText ?
+                    <HoverTip icon={questionIcon}
+                              outerText={"Help"}
+                              toolTipText={pageHelpText}
+                              divClassName={"page-help-tip"}
+                              textClassname
+                    /> : null
+                }
                 {children}
             </div>
         </div>

--- a/task-management-system/imports/ui/components/pages/SignInPage.jsx
+++ b/task-management-system/imports/ui/components/pages/SignInPage.jsx
@@ -77,9 +77,13 @@ export const SignInPage = () => {
 
     return (
         <div>
-            <h1 style={{position:"absolute", top:"80px", width:"100%"}}
-                className={"text-center"}> Welcome to Task Management System</h1>
             <WhiteBackground pageLayout={PageLayout.SMALL_CENTER}>
+                <div>
+                    <h2 className={"text-center text-grey"}>Welcome to</h2>
+                    <h1 className={"text-center"} style={{color: "var(--navy)"}}>Task Management System</h1>
+                </div>
+
+                <hr className={"teams__hr"} />
 
                 <h1 className={"default__heading1"}>Sign In</h1>
 


### PR DESCRIPTION
- Edited landing page title, 
![image](https://github.com/user-attachments/assets/5bd75c11-a3c0-4651-aa63-3c49d53cbd0c)

- help text icon wont appear if filled provided text
![image](https://github.com/user-attachments/assets/3c27c005-3122-4eff-8b78-4568f02c025d)
![image](https://github.com/user-attachments/assets/26337202-11b8-473f-baa2-4cf72d192f74)
